### PR TITLE
akatz dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfydock_server"
-version = "0.1.5"
+version = "0.1.6"
 description = "ComfyDock Server"
 readme = "README.md"
 authors = [
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "comfydock-core>=0.1.3",
+    "comfydock-core>=0.1.4",
     "fastapi[all]>=0.115.8",
     "pydantic>=2.10.6",
     "pydantic-settings>=2.7.1",

--- a/uv.lock
+++ b/uv.lock
@@ -15,11 +15,11 @@ wheels = [
 
 [[package]]
 name = "aiohappyeyeballs"
-version = "2.4.6"
+version = "2.4.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/08/07/508f9ebba367fc3370162e53a3cfd12f5652ad79f0e0bfdf9f9847c6f159/aiohappyeyeballs-2.4.6.tar.gz", hash = "sha256:9b05052f9042985d32ecbe4b59a77ae19c006a78f1344d7fdad69d28ded3d0b0", size = 21726 }
+sdist = { url = "https://files.pythonhosted.org/packages/de/7c/79a15272e88d2563c9d63599fa59f05778975f35b255bf8f90c8b12b4ada/aiohappyeyeballs-2.4.8.tar.gz", hash = "sha256:19728772cb12263077982d2f55453babd8bec6a052a926cd5c0c42796da8bf62", size = 22337 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/4c/03fb05f56551828ec67ceb3665e5dc51638042d204983a03b0a1541475b6/aiohappyeyeballs-2.4.6-py3-none-any.whl", hash = "sha256:147ec992cf873d74f5062644332c539fcd42956dc69453fe5204195e560517e1", size = 14543 },
+    { url = "https://files.pythonhosted.org/packages/52/0e/b187e2bb3eeb2644515109657c4474d65a84e7123de249bf1e8467d04a65/aiohappyeyeballs-2.4.8-py3-none-any.whl", hash = "sha256:6cac4f5dd6e34a9644e69cf9021ef679e4394f54e58a183056d12009e42ea9e3", size = 15005 },
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "comfydock-core"
-version = "0.1.3"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiodocker" },
@@ -190,14 +190,14 @@ dependencies = [
     { name = "filelock" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/80/3f571ff09dd71d4e2594cf2f5386fc4eff2f892bf459b57008d25367a76b/comfydock_core-0.1.3.tar.gz", hash = "sha256:be1c4edbff9546c21d09449f9af8e9ece5e205e6420884bbadf96b85faebb493", size = 60107 }
+sdist = { url = "https://files.pythonhosted.org/packages/15/30/8397aa620693b75f4441fc592c826019abb5d038dae55551dc1b11daff69/comfydock_core-0.1.4.tar.gz", hash = "sha256:54bfdc4092d68693f8e9e265e016a3814de2ce0e13f95c703d6d7033059b61f0", size = 60269 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/b7/8b0937941260b3da9a117358491548bbb96d6711edfd8a0fc64533e482b7/comfydock_core-0.1.3-py3-none-any.whl", hash = "sha256:82b4be7ef5eaf5ecfa6ca23661649b01c76b76a0bafea7743ad7e89aa9dee0f7", size = 15734 },
+    { url = "https://files.pythonhosted.org/packages/23/d7/746fb15890da80bcc17518ef4a2fa9840dfaae5971be94d19335b535e0be/comfydock_core-0.1.4-py3-none-any.whl", hash = "sha256:f280f9c40c9621a8b57bf12c85c82b824338c5013e6b68f6abd92529b7cfec0c", size = 15949 },
 ]
 
 [[package]]
 name = "comfydock-server"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "comfydock-core" },
@@ -211,7 +211,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "comfydock-core", specifier = ">=0.1.3" },
+    { name = "comfydock-core", specifier = ">=0.1.4" },
     { name = "fastapi", extras = ["all"], specifier = ">=0.115.8" },
     { name = "pydantic", specifier = ">=2.10.6" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },


### PR DESCRIPTION
- **More logging added, new routes for installed images**
- **Updated image routes with more logs**
- **Updated default config docker tags url**
- **Updated core version to 0.1.2**
- **Updated workflow to remove cache and use latest uv version**
- **Update uv.lock**
- **Bump version to 0.1.4**
- **Added more logging, updated get image tags to use different dockerhub URL formats**
- **Updated with latest version of comfydock_core**
- **Bump version to use core 0.1.4**
